### PR TITLE
Add 'vw t6' to transporter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -299,7 +299,7 @@ const getModel = car => {
     if (car.name.match(/touran/i)) {
       return Model[Make.VOLKSWAGEN].TOURAN
     }
-    if (car.name.match(/(kassevogn|transporter)/i)) {
+    if (car.name.match(/(kassevogn|transporter|vw t6)/i)) {
       return Model[Make.VOLKSWAGEN].TRANSPORTER
     }
     if (car.name.match(/(up!|up( |$))/i)) {


### PR DESCRIPTION
The new one is simply called
`VW T6 Lang Startline 2,0 TDI 102 5 Gear` for instance.

Waiting just a second with this PR if more outliers are found.

Actually don't do this since:
VW T6 Caravelle Lang CL 2,0TDI 150hk DSG7
VW T6 Lang Kassevogn 2,0 TDI 204 hk DSG
VW T6 Lang Enkeltkabine Alulad 2,0 TDI 102
VW T6 Multivan Kort CL 2,0TDI 204hk DSG7

Can't check on `Lang` either, since several models use that, same case for `Startline`.
Can't use `KSV` or `Kassevogn` either since some of those are Crafters.