### PR TITLE
Add TRP to get-model, add new function to get horse power

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const getEngineSize = require('./resolvers/get-engine-size')
 const getFuelType = require('./resolvers/get-fuel-type')
 const getYear = require('./resolvers/get-year')
 const validateVIN = require('./validators/validate-vin')
-const getEngineHorspower = require('./resolvers/get-engine-hp')
+const getEngineHorsepower = require('./resolvers/get-engine-hp')
 
 module.exports = {
   Make,
@@ -19,5 +19,5 @@ module.exports = {
   getFuelType,
   getYear,
   validateVIN,
-  getEngineHorspower
+  getEngineHorsepower
 }

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ const getEngineSize = require('./resolvers/get-engine-size')
 const getFuelType = require('./resolvers/get-fuel-type')
 const getYear = require('./resolvers/get-year')
 const validateVIN = require('./validators/validate-vin')
+const getEngineHorspower = require('./resolvers/get-engine-hp')
 
 module.exports = {
   Make,
@@ -17,5 +18,6 @@ module.exports = {
   getEngineSize,
   getFuelType,
   getYear,
-  validateVIN
+  validateVIN,
+  getEngineHorspower
 }

--- a/src/resolvers/get-engine-hp.js
+++ b/src/resolvers/get-engine-hp.js
@@ -1,7 +1,7 @@
 const getEngineHorsepowerFromDescription = description => {
   const match = description.match(/(\d{2}|\d{3})(| )hk|(\d{2}|\d{3})(| )hp/)
   if (match) {
-    return parseInt(match[1] || match[2])
+    return parseInt(match[1] || match[3])
   }
   return null
 }

--- a/src/resolvers/get-engine-hp.js
+++ b/src/resolvers/get-engine-hp.js
@@ -1,0 +1,19 @@
+const getEngineHorsepowerFromDescription = description => {
+  const match = description.match(/(\d{2}|\d{3})(| )hk|(\d{2}|\d{3})(| )hp/)
+  if (match) {
+    return parseInt(match[1] || match[2])
+  }
+  return null
+}
+
+/**
+ * Returns the engine horsepower given the description
+ * @param {string} description description formatted as `102hk,80hk,102hp,80hp`
+ */
+module.exports = description => {
+  let engineSize = null
+  if (description) {
+    engineSize = getEngineHorsepowerFromDescription(description.toLowerCase())
+  }
+  return engineSize
+}

--- a/src/resolvers/get-engine-hp.test.js
+++ b/src/resolvers/get-engine-hp.test.js
@@ -19,7 +19,9 @@ const cases = [
   { description: 'Transporter T6 2.0 TDI BMT 4MOTION (204hk)', result: 204 },
   { description: 'Transporter T6 2.0 TDI BMT (150hk)', result: 150 },
   { description: 'Transporter T5 2.0 TDI Pickup (140hk)', result: 140 },
-  { description: 'Transporter skåp', result: null }
+  { description: 'Transporter skåp', result: null },
+  { description: 'TRP PROLINE P-U EH 102HP 300', result: 102 },
+  { description: 'TRP PROLINE P-U DH 102 HP 340', result: 102 }
 ]
 
 describe('get-engine-hp', () => {

--- a/src/resolvers/get-engine-hp.test.js
+++ b/src/resolvers/get-engine-hp.test.js
@@ -1,0 +1,33 @@
+const expect = require('unexpected')
+const getEngineHorsepower = require('./get-engine-hp')
+
+const cases = [
+  { description: 'CADDY TRENDL EU6 TSI 84HK', result: 84 },
+  { description: 'CADDY TRENDL EU6 TSI 125HK DSG', result: 125 },
+  { description: 'CADDY TRENDL 1,0 TSI 84 HK', result: 84 },
+  { description: 'CADDY SKÅP EU6 TSI 84HK', result: 84 },
+  { description: 'CADDY SKÅP 1,2 TSI 84HK', result: 84 },
+  { description: 'Caddy Maxi Trendline 1,0 TSI 102hk man', result: 102 },
+  { description: 'CADDY CONCEPTL TSI 84HK', result: 84 },
+  { description: 'TRP PROLINE SKÅP 102HK 340', result: 102 },
+  { description: 'TRP PROLINE SKÅP 102HK 300', result: 102 },
+  { description: 'TRP PROLINE P-U EH 102HK 340', result: 102 },
+  { description: 'TRP PROLINE P-U EH 102HK 300', result: 102 },
+  { description: 'TRP PROLINE P-U DH 102HK 340', result: 102 },
+  { description: 'TRP KOM 150HK TDI DSG', result: 150 },
+  { description: 'Transporter T6 2.0 TDI BMT Skåp (150hk)', result: 150 },
+  { description: 'Transporter T6 2.0 TDI BMT 4MOTION (204hk)', result: 204 },
+  { description: 'Transporter T6 2.0 TDI BMT (150hk)', result: 150 },
+  { description: 'Transporter T5 2.0 TDI Pickup (140hk)', result: 140 },
+  { description: 'Transporter skåp', result: null }
+]
+
+describe('get-engine-hp', () => {
+  describe('getEngineHorsepower', () => {
+    for (const { description, result } of cases) {
+      it(`resolves engine for ${description} (${result})`, () => {
+        expect(getEngineHorsepower(description), 'to equal', result)
+      })
+    }
+  })
+})

--- a/src/resolvers/get-model.js
+++ b/src/resolvers/get-model.js
@@ -296,7 +296,7 @@ const getModelFromMakeDescription = (make, description) => {
       if (description.match(/touran/i)) {
         return Model[make].TOURAN
       }
-      if (description.match(/(kassevogn|transporter|vw t5|(^t5)|vw t6|(^t6))/i)) {
+      if (description.match(/(kassevogn|transporter|vw t5|(^t5)|vw t6|(^t6)|(^TRP))/i)) {
         return Model[make].TRANSPORTER
       }
       if (description.match(/(up!|up(\W| |$))/i)) {

--- a/src/resolvers/get-model.test.js
+++ b/src/resolvers/get-model.test.js
@@ -36,6 +36,12 @@ const cases = [
   { vin: 'WVWAAAAAAAA123456', name: 'VW T6 DKLAD Lang Enkeltkabine 2,0 TDI', result: 'Transporter' },
   { vin: 'WVWAAAAAAAA123456', name: 'VW T6 DKLAD Lang Enkeltkabine 2,0 TDI', result: 'Transporter' },
   { vin: 'WVWAAAAAAAA123456', name: 'VW T6 DKLAD Lang Enkeltkabine 2,0 TDI', result: 'Transporter' },
+
+  { vin: 'WVWAAAAAAAA123456', name: 'TRP PROLINE P-U DH 102HK 340', result: 'Transporter' },
+  { vin: 'WVWAAAAAAAA123456', name: 'TRP PROLINE SKÅP 102HK 300', result: 'Transporter' },
+  { vin: 'WVWAAAAAAAA123456', name: 'TRP KOM 150HK TDI DSG', result: 'Transporter' },
+  { vin: 'WVWAAAAAAAA123456', name: 'TRP PROLINE P-U EH 102HK 340', result: 'Transporter' },
+
   { vin: 'WVWAAAAAAAA123456', name: 'VW T6 Lang Enka 2,0TDI 102hk 5G', result: 'Transporter' },
   { vin: 'WVWAAAAAAAA123456', name: 'VW T5 CHASSIS LANG 2,0 TDI 140 HK BMT 6G', result: 'Transporter' },
   { vin: 'WVWAAAAAAAA123456', name: 'VW T6 Kort Enka 2,0TDI 84hk 5G', result: 'Transporter' },


### PR DESCRIPTION
* Extends `get-model` to also parse "TRP" as a transporter
* Adds new function to get horse power