### PR TITLE
Feature/add support for more models in fuel type

### DIFF
--- a/src/resolvers/get-fuel-type.js
+++ b/src/resolvers/get-fuel-type.js
@@ -8,12 +8,12 @@ const getFuelTypeFromDescription = description => {
     return FuelType.HYBRID_DIESEL
   }
   if (
-    description.match(/(gte|a3.+e-tron|q7.+e-tron|tfsi e)/i) ||
+    description.match(/(gte|a3.+e-tron|q7.+e-tron|tfsi ?e)/i) ||
     (description.match(/hybrid/i) && !description.match(/mild hybrid/i))
   ) {
     return FuelType.HYBRID
   }
-  if (description.match(/(e-golf|citigoe|mii electric|e-up!|e-up( |$)|e-tron|id\.3)/i)) {
+  if (description.match(/(e-golf|citigoe|mii electric|e-up!|e-up( |$)|e-tron|id\.[3-5]|e-crafter)/i)) {
     return FuelType.ELECTRIC
   }
   if (description.match(/(sdi|tdi)/i)) {

--- a/src/resolvers/get-fuel-type.js
+++ b/src/resolvers/get-fuel-type.js
@@ -7,6 +7,10 @@ const getFuelTypeFromDescription = description => {
   if (description.match(/e-tron/i) && description.match(/tdi/i)) {
     return FuelType.HYBRID_DIESEL
   }
+  // Some of the following regexes uses negative look-behinds to account for
+  // malicious input that will cause them to perform poorly.
+  //
+  // https://codeql.github.com/codeql-query-help/javascript/js-polynomial-redos/
   if (
     description.match(/(gte|(?<!(a3))a3.+e-tron|(?<!(q7))q7.+e-tron|tfsi ?e)/i) ||
     (description.match(/hybrid/i) && !description.match(/mild hybrid/i))

--- a/src/resolvers/get-fuel-type.js
+++ b/src/resolvers/get-fuel-type.js
@@ -8,7 +8,7 @@ const getFuelTypeFromDescription = description => {
     return FuelType.HYBRID_DIESEL
   }
   if (
-    description.match(/(gte|a3.+e-tron|q7.+e-tron|tfsi ?e)/i) ||
+    description.match(/(gte|(?<!(a3))a3.+e-tron|(?<!(q7))q7.+e-tron|tfsi ?e)/i) ||
     (description.match(/hybrid/i) && !description.match(/mild hybrid/i))
   ) {
     return FuelType.HYBRID

--- a/src/resolvers/get-fuel-type.test.js
+++ b/src/resolvers/get-fuel-type.test.js
@@ -33,6 +33,7 @@ const cases = [
   { vin: '', name: 'Audi Q7 SUV e-tron 3,0 TDI 374 hk 275 kW E-tr', result: FuelType.HYBRID_DIESEL },
   { vin: '', name: 'Audi Q7 SUV TdI 3,0 E-tRoN 374 hk 275 kW E-tr', result: FuelType.HYBRID_DIESEL },
   { vin: '', name: 'VW ID.4 1st 204HK AUT1 Performance', result: FuelType.ELECTRIC },
+  { vin: '', name: 'VW ID.6 1st 204HK AUT1 Performance', result: null },
   { vin: '', name: 'VW e-Crafter L3 Kassevogn EL 136HK AUT1G', result: FuelType.ELECTRIC },
   { vin: '', name: 'AUDI A6 ALLROAD 3,0 TFSIe 333 HK 245 KW QUATTR', result: FuelType.HYBRID }
 ]

--- a/src/resolvers/get-fuel-type.test.js
+++ b/src/resolvers/get-fuel-type.test.js
@@ -31,7 +31,10 @@ const cases = [
   { vin: '', name: 'SKODA OCTAVIA A8 COMBI Style 1ED 1,0 eTSI 110', result: FuelType.GASOLINE },
   { vin: '', name: 'Audi Q7 e-tron 3,0 TDI qua 258 HK tip', result: FuelType.HYBRID_DIESEL },
   { vin: '', name: 'Audi Q7 SUV e-tron 3,0 TDI 374 hk 275 kW E-tr', result: FuelType.HYBRID_DIESEL },
-  { vin: '', name: 'Audi Q7 SUV TdI 3,0 E-tRoN 374 hk 275 kW E-tr', result: FuelType.HYBRID_DIESEL }
+  { vin: '', name: 'Audi Q7 SUV TdI 3,0 E-tRoN 374 hk 275 kW E-tr', result: FuelType.HYBRID_DIESEL },
+  { vin: '', name: 'VW ID.4 1st 204HK AUT1 Performance', result: FuelType.ELECTRIC },
+  { vin: '', name: 'VW e-Crafter L3 Kassevogn EL 136HK AUT1G', result: FuelType.ELECTRIC },
+  { vin: '', name: 'AUDI A6 ALLROAD 3,0 TFSIe 333 HK 245 KW QUATTR', result: FuelType.HYBRID }
 ]
 
 describe('get-fuel-type', () => {


### PR DESCRIPTION
[ch-42945]
[skip-ch]

One might change the ID range to cover a broader range of numbers to support all future models but at the moment only `ID.4` exists as a pretty new model and `ID.5` has only been announced.