### PR TITLE
Fix versioning by "skipping" v2.0.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connectedcars/vinutils",
-  "version": "2.0.15",
+  "version": "2.0.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@connectedcars/vinutils",
-      "version": "2.0.15",
+      "version": "2.0.17",
       "license": "MIT",
       "devDependencies": {
         "babel-eslint": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedcars/vinutils",
-  "version": "2.0.15",
+  "version": "2.0.17",
   "description": "Utilities to extract model and engine information from vin and car description text",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
I bumped the version to 2.0.16 last time but apparently forgot to push the branch so the tag exists but not the commit. Since the tag exists, I cannot run `npm version patch`. Moving the tag will probably cause issues with `npm publish` so instead I did a manual bump.

Running `npm publish --dry-run` has no issues.