### PR TITLE
chore(): add PR template on bumping other repos

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+### When you make changes to `node-vinutils` you need to bump the following repos:
+
+
+ | Repository |  Packages to bump |
+|---|---|
+|  https://github.com/connectedcars/node-backend/ |  `node-vinutils` |
+|  https://github.com/connectedcars/node-integration/ |  `node-vinutils`, `node-backend`|
+|  https://github.com/connectedcars/integration/ |   `node-backend`, `node-integration` |
+|  https://github.com/connectedcars/api/ |   `node-vinutils`, `node-backend`, `node-integration` |
+|  https://github.com/connectedcars/notifier/ |   `node-vinutils`, `node-backend`, `node-integration` |
+|  https://github.com/connectedcars/job-runner-rollouts/ |  `node-backend` |
+|  https://github.com/connectedcars/job-runner-integration/ |  `node-backend` |


### PR DESCRIPTION
### When you make changes to `node-vinutils` you need to bump the following repos:


 | Repository |  Packages to bump |
|---|---|
|  https://github.com/connectedcars/node-backend/ |  `node-vinutils` |
|  https://github.com/connectedcars/node-integration/ |  `node-vinutils`, `node-backend`|
|  https://github.com/connectedcars/integration/ |   `node-backend`, `node-integration` |
|  https://github.com/connectedcars/api/ |   `node-vinutils`, `node-backend`, `node-integration` |
|  https://github.com/connectedcars/notifier/ |   `node-vinutils`, `node-backend`, `node-integration` |
|  https://github.com/connectedcars/job-runner-rollouts/ |  `node-backend` |
|  https://github.com/connectedcars/job-runner-integration/ |  `node-backend` |
