### PR TITLE
Remove integration test section

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,3 @@ Utilities to extract model and engine information from vin and car description t
 ```
 npm install @connectedcars/vinutils
 ```
-
-## Test
-Run integration tests via (takes several minutes to run):
-```
-npm run integration
-```


### PR DESCRIPTION
Not relevant after #70. Not bumping.

### When you make changes to `node-vinutils` you need to bump the following repos:


 | Repository |  Packages to bump |
|---|---|
|  https://github.com/connectedcars/node-backend/ |  `node-vinutils` |
|  https://github.com/connectedcars/vehicle-configs/ |  `node-vinutils` |
|  https://github.com/connectedcars/node-integration/ |  `node-vinutils`, `node-backend`|
|  https://github.com/connectedcars/integration/ |   `node-backend`, `node-integration` |
|  https://github.com/connectedcars/api/ |   `node-vinutils`, `node-backend`, `node-integration` |
|  https://github.com/connectedcars/notifier/ |   `node-vinutils`, `node-backend`, `node-integration` |
|  https://github.com/connectedcars/job-runner-rollouts/ |  `node-backend` |
|  https://github.com/connectedcars/job-runner-integration/ |  `node-backend` |
