### PR TITLE
Update pull request template [skip ci]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,12 @@
 ### When you make changes to `node-vinutils` you need to bump the following repos:
 
-
- | Repository |  Packages to bump |
-|---|---|
-|  https://github.com/connectedcars/node-backend/ |  `node-vinutils` |
-|  https://github.com/connectedcars/vehicle-configs/ |  `node-vinutils` |
-|  https://github.com/connectedcars/node-integration/ |  `node-vinutils`, `node-backend`|
-|  https://github.com/connectedcars/integration/ |   `node-backend`, `node-integration` |
-|  https://github.com/connectedcars/api/ |   `node-vinutils`, `node-backend`, `node-integration` |
-|  https://github.com/connectedcars/notifier/ |   `node-vinutils`, `node-backend`, `node-integration` |
-|  https://github.com/connectedcars/job-runner-rollouts/ |  `node-backend` |
-|  https://github.com/connectedcars/job-runner-integration/ |  `node-backend` |
+| Repository                                               | Packages to bump                                    |
+| -------------------------------------------------------- | --------------------------------------------------- |
+| https://github.com/connectedcars/node-backend/           | `node-vinutils`                                     |
+| https://github.com/connectedcars/vehicle-configs/        | `node-vinutils`                                     |
+| https://github.com/connectedcars/node-integration/       | `node-vinutils`                                     |
+| https://github.com/connectedcars/integration/            | `node-backend`, `node-integration`                  |
+| https://github.com/connectedcars/api/                    | `node-vinutils`, `node-backend`, `node-integration` |
+| https://github.com/connectedcars/notifier/               | `node-vinutils`, `node-backend`, `node-integration` |
+| https://github.com/connectedcars/job-runner-rollouts/    | `node-backend`                                      |
+| https://github.com/connectedcars/job-runner-integration/ | `node-backend`                                      |


### PR DESCRIPTION
node-integration's dependency on node-backend was removed in connectedcars/node-integration#100.

### When you make changes to `node-vinutils` you need to bump the following repos:


 | Repository |  Packages to bump |
|---|---|
|  https://github.com/connectedcars/node-backend/ |  `node-vinutils` |
|  https://github.com/connectedcars/vehicle-configs/ |  `node-vinutils` |
|  https://github.com/connectedcars/node-integration/ |  `node-vinutils`, `node-backend`|
|  https://github.com/connectedcars/integration/ |   `node-backend`, `node-integration` |
|  https://github.com/connectedcars/api/ |   `node-vinutils`, `node-backend`, `node-integration` |
|  https://github.com/connectedcars/notifier/ |   `node-vinutils`, `node-backend`, `node-integration` |
|  https://github.com/connectedcars/job-runner-rollouts/ |  `node-backend` |
|  https://github.com/connectedcars/job-runner-integration/ |  `node-backend` |
