### PR TITLE
Add Crafter to VW commercial vehicles

### DIFF
--- a/src/resolvers/get-model.test.ts
+++ b/src/resolvers/get-model.test.ts
@@ -688,7 +688,8 @@ const cases = [
     { name: 'Multivan 2,0 TDI', result: Model[Make.VOLKSWAGEN_COMMERCIAL_VEHICLES].MULTIVAN },
     { name: 'VW T6 DKLAD Lang Enkeltkabine 2,0 TDI', result: Model[Make.VOLKSWAGEN_COMMERCIAL_VEHICLES].TRANSPORTER },
     { name: 'TRP PROLINE P-U DH 102HK 340', result: Model[Make.VOLKSWAGEN_COMMERCIAL_VEHICLES].TRANSPORTER },
-    { name: 'ID.Buzz', result: Model[Make.VOLKSWAGEN_COMMERCIAL_VEHICLES]['ID.Buzz'] }
+    { name: 'ID.Buzz', result: Model[Make.VOLKSWAGEN_COMMERCIAL_VEHICLES]['ID.Buzz'] },
+    { name: 'VW Crafter 35 Enka 4325mm 2,0 TDI 136 hk', result: Model[Make.VOLKSWAGEN_COMMERCIAL_VEHICLES].CRAFTER }
   ].map(addVinToTest('WV1ZZZAAZFD123456'))
 ]
 

--- a/src/resolvers/get-model.ts
+++ b/src/resolvers/get-model.ts
@@ -527,6 +527,9 @@ function getModelFromMakeDescription(make: Make, description: string): string | 
       if (description.match(/caddy/i)) {
         return Model[make].CADDY
       }
+      if (description.match(/crafter/i)) {
+        return Model[make].CRAFTER
+      }
       if (description.match(/grand california/i)) {
         return Model[make].GRAND_CALIFORNIA
       }


### PR DESCRIPTION
[sc-96398]
[skip-sc]

### When you make changes to `node-vinutils` you need to bump the following repos:

| Repository                                               | Packages to bump                                    |
| -------------------------------------------------------- | --------------------------------------------------- |
| https://github.com/connectedcars/node-backend/           | `node-vinutils`                                     |
| https://github.com/connectedcars/vehicle-configs/        | `node-vinutils`                                     |
| https://github.com/connectedcars/node-integration/       | `node-vinutils`                                     |
| https://github.com/connectedcars/integration/            | `node-backend`, `node-integration`                  |
| https://github.com/connectedcars/api/                    | `node-vinutils`, `node-backend`, `node-integration` |
| https://github.com/connectedcars/notifier/               | `node-vinutils`, `node-backend`, `node-integration` |
| https://github.com/connectedcars/job-runner-rollouts/    | `node-backend`                                      |
| https://github.com/connectedcars/job-runner-integration/ | `node-backend`                                      |
