### PR TITLE
Add node-integration dep to node-backend

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,9 +2,9 @@
 
 | Repository                                               | Packages to bump                                    |
 | -------------------------------------------------------- | --------------------------------------------------- |
-| https://github.com/connectedcars/node-backend/           | `node-vinutils`                                     |
 | https://github.com/connectedcars/vehicle-configs/        | `node-vinutils`                                     |
 | https://github.com/connectedcars/node-integration/       | `node-vinutils`                                     |
+| https://github.com/connectedcars/node-backend/           | `node-vinutils`, `node-integration`                 |
 | https://github.com/connectedcars/integration/            | `node-backend`, `node-integration`                  |
 | https://github.com/connectedcars/api/                    | `node-vinutils`, `node-backend`, `node-integration` |
 | https://github.com/connectedcars/notifier/               | `node-vinutils`, `node-backend`, `node-integration` |


### PR DESCRIPTION
node-backend depends on node-integration, so I added it.

### When you make changes to `node-vinutils` you need to bump the following repos:

| Repository                                               | Packages to bump                                    |
| -------------------------------------------------------- | --------------------------------------------------- |
| https://github.com/connectedcars/node-backend/           | `node-vinutils`                                     |
| https://github.com/connectedcars/vehicle-configs/        | `node-vinutils`                                     |
| https://github.com/connectedcars/node-integration/       | `node-vinutils`                                     |
| https://github.com/connectedcars/integration/            | `node-backend`, `node-integration`                  |
| https://github.com/connectedcars/api/                    | `node-vinutils`, `node-backend`, `node-integration` |
| https://github.com/connectedcars/notifier/               | `node-vinutils`, `node-backend`, `node-integration` |
| https://github.com/connectedcars/job-runner-rollouts/    | `node-backend`                                      |
| https://github.com/connectedcars/job-runner-integration/ | `node-backend`                                      |
