### PR TITLE
Fix vins for Cupra Tavascan and Terramar

### DIFF
--- a/src/constants/model.ts
+++ b/src/constants/model.ts
@@ -84,7 +84,8 @@ export const Model = {
     BORN: 'Born',
     FORMENTOR: 'Formentor',
     LEON: 'Leon',
-    TAVASCAN: 'Tavascan'
+    TAVASCAN: 'Tavascan',
+    TERRAMAR: 'Terramar'
   },
   [Make.DACIA]: {
     DOKKER: 'Dokker',

--- a/src/resolvers/get-make.ts
+++ b/src/resolvers/get-make.ts
@@ -523,7 +523,10 @@ function getMakeFromVin(vin: string, modelCode?: string | null): Make | null {
     case 'VSS': {
       // vins starting with VSSZZZKM will always be a CUPRA Formentor
       // vins starting with VSSZZZK1 will always be a CUPRA Born
-      if (vin.startsWith('VSSZZZKM') || vin.startsWith('VSSZZZK1')) {
+      // vins starting with VSSZZZKR will always be a CUPRA Tavascan
+      // vins starting with VSSZZZKP will always be a CUPRA Terramar
+      const cupraVins = ['VSSZZZKM', 'VSSZZZK1', 'VSSZZZKR', 'VSSZZZKP']
+      if (cupraVins.includes(vin.substring(0, 8).toUpperCase())) {
         return Make.CUPRA
       }
       switch (modelCode) {

--- a/src/resolvers/get-model.test.ts
+++ b/src/resolvers/get-model.test.ts
@@ -807,6 +807,8 @@ const cases = [
 
   ...[{ name: 'Formentor', result: Model[Make.CUPRA].FORMENTOR }].map(addVinToTest('VSSZZZKMZGR123456')),
   ...[{ name: 'Born', result: Model[Make.CUPRA].BORN }].map(addVinToTest('VSSZZZK1ZGR123456')),
+  ...[{ name: 'Tavascan', result: Model[Make.CUPRA].TAVASCAN }].map(addVinToTest('VSSZZZKRZGR123456')),
+  ...[{ name: 'Terramar', result: Model[Make.CUPRA].TERRAMAR }].map(addVinToTest('VSSZZZKPZGR123456')),
 
   ...[
     { name: 'Ateca', result: Model[Make.SEAT].ATECA },

--- a/src/resolvers/get-model.ts
+++ b/src/resolvers/get-model.ts
@@ -152,6 +152,9 @@ function getModelFromMakeDescription(make: Make, description: string): string | 
       if (description.match(/tavascan/i)) {
         return Model[make].TAVASCAN
       }
+      if (description.match(/terramar/i)) {
+        return Model[make].TERRAMAR
+      }
       break
     }
     case Make.DACIA: {


### PR DESCRIPTION
[[sc-124119](https://app.shortcut.com/connectedcars/story/124119/cupra-tavascan-is-seat-in-semler-system)]

### When you make changes to `node-vinutils` you need to bump the following repos:

| Repository                                               | Packages to bump                                    |
| -------------------------------------------------------- | --------------------------------------------------- |
| https://github.com/connectedcars/vehicle-configs/        | `node-vinutils`                                     |
| https://github.com/connectedcars/node-integration/       | `node-vinutils`                                     |
| https://github.com/connectedcars/node-backend/           | `node-vinutils`, `vehicle-configs`                  |
| https://github.com/connectedcars/integration/            | `node-backend`, `node-integration`                  |
| https://github.com/connectedcars/api/                    | `node-vinutils`, `node-backend`.                    |
| https://github.com/connectedcars/notifier/               | `node-vinutils`, `node-backend`, `node-integration` |
| https://github.com/connectedcars/job-runner-rollouts/    | `node-backend`                                      |
| https://github.com/connectedcars/job-runner-integration/ | `node-backend`                                      |
