### PR TITLE
Switches WV4 WMI to Volkswagen Commercial Vehicles

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -28,7 +28,7 @@ describe('index', () => {
     expect(getMake({ vin: '3VVZZZAAZFD123456' })).toBe(Make.VOLKSWAGEN)
     expect(getMake({ vin: 'VW1ZZZAAZFD123456' })).toBe(Make.VOLKSWAGEN)
     expect(getMake({ vin: 'VW2ZZZAAZFD123456' })).toBe(Make.VOLKSWAGEN)
-    expect(getMake({ vin: 'WV4ZZZAAZFD123456' })).toBe(Make.VOLKSWAGEN)
+    expect(getMake({ vin: 'WV4ZZZAAZFD123456' })).toBe(Make.VOLKSWAGEN_COMMERCIAL_VEHICLES)
     expect(getMake({ vin: 'TMBJE73T3E9123456' })).toBe(Make.SKODA)
     expect(getMake({ vin: 'TMPJE73T3E9123456' })).toBe(Make.SKODA)
     expect(getMake({ vin: 'TM9JE73T3E9123456' })).toBe(Make.SKODA)

--- a/src/resolvers/get-make.ts
+++ b/src/resolvers/get-make.ts
@@ -646,13 +646,13 @@ function getMakeFromVin(vin: string, modelCode?: string | null): Make | null {
     case '1V2':
     case '3VV':
     case 'VW1':
-    case 'VW2':
-    case 'WV4': {
+    case 'VW2': {
       return Make.VOLKSWAGEN
     }
     case 'WV1':
     case 'WV2':
-    case 'WV3': {
+    case 'WV3':
+    case 'WV4': {
       return Make.VOLKSWAGEN_COMMERCIAL_VEHICLES
     }
     case 'MC2':


### PR DESCRIPTION
### When you make changes to `node-vinutils` you need to bump the following repos:

| Repository                                               | Packages to bump                                    |
| -------------------------------------------------------- | --------------------------------------------------- |
| https://github.com/connectedcars/vehicle-configs/        | `node-vinutils`                                     |
| https://github.com/connectedcars/node-integration/       | `node-vinutils`                                     |
| https://github.com/connectedcars/node-backend/           | `node-vinutils`, `vehicle-configs`                  |
| https://github.com/connectedcars/integration/            | `node-backend`, `node-integration`                  |
| https://github.com/connectedcars/api/                    | `node-vinutils`, `node-backend`.                    |
| https://github.com/connectedcars/notifier/               | `node-vinutils`, `node-backend`, `node-integration` |
| https://github.com/connectedcars/job-runner-rollouts/    | `node-backend`                                      |
| https://github.com/connectedcars/job-runner-integration/ | `node-backend`                                      |

[sc-131086]
[skip-sc]
