### PR TITLE
bump vinutils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@connectedcars/vinutils",
       "version": "2.2.18",
       "license": "MIT",
+      "dependencies": {
+        "@connectedcars/vinutils": "^2.2.18"
+      },
       "devDependencies": {
         "@babel/cli": "7.24.7",
         "@babel/core": "7.24.7",
@@ -2063,6 +2066,15 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@connectedcars/vinutils": {
+      "version": "2.2.18",
+      "resolved": "https://registry.npmjs.org/@connectedcars/vinutils/-/vinutils-2.2.18.tgz",
+      "integrity": "sha512-2SLe0NrNGhTIF8ppDWqNK7R0pmn4RUdgB2kN8e5t37I/yxw/l2k3R5SnPEYgG3im/z+XRU5JImU/EcR9CVG+Pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -10915,6 +10927,11 @@
         "sinon": "^17.0.1",
         "yargs": "^17.7.2"
       }
+    },
+    "@connectedcars/vinutils": {
+      "version": "2.2.18",
+      "resolved": "https://registry.npmjs.org/@connectedcars/vinutils/-/vinutils-2.2.18.tgz",
+      "integrity": "sha512-2SLe0NrNGhTIF8ppDWqNK7R0pmn4RUdgB2kN8e5t37I/yxw/l2k3R5SnPEYgG3im/z+XRU5JImU/EcR9CVG+Pg=="
     },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
     "prettier": "3.3.2",
     "typescript": "5.5.3"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@connectedcars/vinutils": "^2.2.18"
+  },
   "engines": {
     "node": ">=20.0.0"
   }


### PR DESCRIPTION
[[sc-146458][skip-sc]

### When you make changes to `node-vinutils` you need to bump the following repos:

| Repository                                               | Packages to bump                                    |
| -------------------------------------------------------- | --------------------------------------------------- |
| https://github.com/connectedcars/vehicle-configs/        | `node-vinutils`                                     |
| https://github.com/connectedcars/node-integration/       | `node-vinutils`                                     |
| https://github.com/connectedcars/node-backend/           | `node-vinutils`, `vehicle-configs`                  |
| https://github.com/connectedcars/integration/            | `node-backend`, `node-integration`                  |
| https://github.com/connectedcars/api/                    | `node-vinutils`, `node-backend`.                    |
| https://github.com/connectedcars/notifier/               | `node-vinutils`, `node-backend`, `node-integration` |
| https://github.com/connectedcars/job-runner-rollouts/    | `node-backend`                                      |
| https://github.com/connectedcars/job-runner-integration/ | `node-backend`, `vehicle-configs`, `node-vinutils`  |
| https://github.com/connectedcars/external-lookup/        | `node-vinutils`, `node-backend`.                    |
